### PR TITLE
Enable remote CMS editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Nini Book Reviews
 
 This is a cosy book review website built with **Jekyll** and **Netlify CMS**.
-It can be hosted for free on GitHub Pages and allows content editing through a
-simple web interface provided by Netlify.
+Deploy it to Netlify or GitHub Pages and manage content through the
+Netlify CMS interface.
 
 ## Usage
 
-1. Run `bundle exec jekyll serve` to preview the site locally.
-2. Visit `http://localhost:4000/admin/` for the content manager. The CMS is
-   configured with `local_backend: true` so you can log in and create posts
-   without any extra setup.
-3. Uploaded images are stored in `assets/images`.
+1. Deploy the site and visit `/admin/` to log in with your Git provider.
+   Book reviews are created in Markdown and images are uploaded to
+   `assets/images` automatically.
+2. (Optional) Run `bundle exec jekyll serve` to preview the site locally.
 
 ## Structure
 - `index.html` – homepage listing all book reviews

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,7 +2,8 @@ backend:
   name: git-gateway
   branch: main
 
-local_backend: true
+# Use the remote Git backend when editing through Netlify CMS
+# Removing `local_backend: true` enables full online editing
 publish_mode: editorial_workflow
 
 media_folder: "assets/images"


### PR DESCRIPTION
## Summary
- switch Netlify CMS to the remote Git backend
- update instructions for online editing

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d78fe1410832f96ae967d751a936a