### PR TITLE
Fix CMS settings for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Nini Book Reviews
 
 This is a cosy book review website built with **Jekyll** and **Netlify CMS**.
-Deploy it to Netlify or GitHub Pages and manage content through the
-Netlify CMS interface.
+Deploy it to Netlify or GitHub Pages and manage content through the Netlify
+CMS interface. When hosting on GitHub Pages the CMS needs to commit directly to
+your repository, so the `admin/config.yml` file uses the GitHub backend with a
+placeholder repository value. Replace `yourusername/nini_bennet_moll` with your
+own GitHub repository before going live.
 
 ## Usage
 
-1. Deploy the site and visit `/admin/` to log in with your Git provider.
+1. Deploy the site and visit `/admin/` to log in with your GitHub account.
    Book reviews are created in Markdown and images are uploaded to
-   `assets/images` automatically.
+   `assets/images` automatically. Ensure the backend configuration in
+   `admin/config.yml` points to your repository so the CMS can save posts.
 2. (Optional) Run `bundle exec jekyll serve` to preview the site locally.
 
 ## Structure

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,5 +1,8 @@
 backend:
-  name: git-gateway
+  # Use the GitHub backend so the CMS can commit directly to your repository
+  # Replace "yourusername" and "yourrepo" with your actual GitHub details
+  name: github
+  repo: yourusername/nini_bennet_moll
   branch: main
 
 # Use the remote Git backend when editing through Netlify CMS


### PR DESCRIPTION
## Summary
- switch Netlify CMS to GitHub backend
- document repository setup for GitHub Pages

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d4c7dac832f89d8cdafe5b41d15