### PR TITLE
Add metadata fields and homepage enhancements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,6 @@ url: "https://obelaiquality.github.io"
 collections:
   posts:
     output: true
+plugins:
+  - jekyll-feed
+  - jekyll-sitemap

--- a/_data/quotes.yml
+++ b/_data/quotes.yml
@@ -1,0 +1,3 @@
+- "A room without books is like a body without a soul."
+- "So many books, so little time."
+- "The only thing you absolutely have to know, is the location of the library."

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>{{ page.title }}</title>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
+  <script>var quotes = {{ site.data.quotes | jsonify }};</script>
   <script defer src="{{ site.baseurl }}/assets/js/main.js"></script>
 </head>
 <body>
@@ -12,6 +13,7 @@
     <nav>
       <a href="{{ site.baseurl }}/">Home</a> |
       <a href="{{ site.baseurl }}/admin/">Admin</a>
+      <button id="dark-toggle">🌙</button>
     </nav>
   </header>
   <div class="container">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,12 +8,37 @@ layout: default
     <p class="author-bio">{{ page.author_bio }}</p>
   {% endif %}
   {% if page.cover %}
-    <img src="{{ site.baseurl }}{{ page.cover }}" alt="{{ page.title }} cover" class="cover">
+    <img src="{{ site.baseurl }}{{ page.cover }}" alt="{{ page.title }} cover" class="cover" loading="lazy">
+  {% endif %}
+  {% if page.rating %}
+    <p class="rating" data-rating="{{ page.rating }}"></p>
   {% endif %}
   <div class="content">
     {{ content }}
   </div>
   {% if page.tags %}
     <p class="tags">Tags: {{ page.tags | array_to_sentence_string }}</p>
-  {% endif %}
+{% endif %}
 </article>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Review",
+  "itemReviewed": {
+    "@type": "Book",
+    "name": "{{ page.title }}",
+    "author": "{{ page.author }}",
+    "datePublished": "{{ page.publication_date }}"
+  },
+  "reviewRating": {
+    "@type": "Rating",
+    "ratingValue": "{{ page.rating }}",
+    "bestRating": "5"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Nini Bennet Moll"
+  },
+  "reviewBody": "{{ page.excerpt | strip_html | truncate: 160 }}"
+}
+</script>

--- a/_posts/2025-06-26-the-alchemist.md
+++ b/_posts/2025-06-26-the-alchemist.md
@@ -3,7 +3,11 @@ title: "The Alchemist"
 author: "Paulo Coelho"
 date: 2025-06-26
 cover: "/assets/images/alchemist.jpg"
+genre: "Fiction"
+publication_date: "1988-04-15"
+rating: 4.5
 tags: [inspiration, fantasy]
+featured: true
 author_bio: "Brazilian lyricist and novelist."
 ---
 A magical story of following one’s dreams and discovering purpose.

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -18,11 +18,15 @@ collections:
     folder: "_posts"
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    fields:
-      - { label: "Title", name: "title", widget: "string" }
-      - { label: "Author", name: "author", widget: "string" }
-      - { label: "Cover", name: "cover", widget: "image" }
-      - { label: "Date", name: "date", widget: "datetime" }
-      - { label: "Author Bio", name: "author_bio", widget: "text", required: false }
-      - { label: "Tags", name: "tags", widget: "list", default: [] }
-      - { label: "Body", name: "body", widget: "markdown" }
+      fields:
+        - { label: "Title", name: "title", widget: "string" }
+        - { label: "Author", name: "author", widget: "string" }
+        - { label: "Genre", name: "genre", widget: "select", options: ["Fiction", "Non-Fiction", "Sci-Fi", "Romance", "Biography"] }
+        - { label: "Publication Date", name: "publication_date", widget: "datetime" }
+        - { label: "Rating", name: "rating", widget: "number", value_type: "float", min: 0, max: 5, step: 0.5 }
+        - { label: "Cover", name: "cover", widget: "image" }
+        - { label: "Date", name: "date", widget: "datetime" }
+        - { label: "Featured", name: "featured", widget: "boolean", default: false }
+        - { label: "Author Bio", name: "author_bio", widget: "text", required: false }
+        - { label: "Tags", name: "tags", widget: "list", default: [] }
+        - { label: "Body", name: "body", widget: "markdown" }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,13 @@ body {
   margin-left: 0.5rem;
   font-size: 1rem;
 }
+.site-header nav button {
+  margin-left: 0.5rem;
+  font-size: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
 .cover {
   max-width: 100%;
   border-radius: 8px;
@@ -75,8 +82,36 @@ a:hover {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+.rating {
+  color: #d4a373;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+.featured-carousel {
+  display: flex;
+  overflow-x: auto;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+.featured-item {
+  min-width: 150px;
+}
+.dark body {
+  background: #1e1e1e;
+  color: #eee;
+}
+.dark .review {
+  background-color: #2c2c2c;
+  border-color: #444;
+}
+.dark a {
+  color: #d4a373;
+}
 .tags {
   font-size: 0.85rem;
   color: #666;
   margin-bottom: 0.5rem;
+}
+.summary {
+  margin-bottom: 1.5rem;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,20 +3,77 @@ document.addEventListener('DOMContentLoaded', function () {
   const searchInput = document.getElementById('search');
   const authorFilter = document.getElementById('author-filter');
   const tagFilter = document.getElementById('tag-filter');
+  const genreFilter = document.getElementById('genre-filter');
+  const ratingFilter = document.getElementById('rating-filter');
+  const yearFilter = document.getElementById('year-filter');
+  const quoteEl = document.getElementById('quote-of-the-day');
+  const darkToggle = document.getElementById('dark-toggle');
+  const topAuthorsEl = document.getElementById('top-authors');
+  const topGenresEl = document.getElementById('top-genres');
+
+  // Display random quote
+  if (quoteEl && window.quotes) {
+    const q = window.quotes[Math.floor(Math.random() * window.quotes.length)];
+    quoteEl.textContent = q;
+  }
+
+  // Dark mode toggle
+  if (darkToggle) {
+    if (localStorage.getItem('dark') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+    darkToggle.addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      localStorage.setItem('dark', document.documentElement.classList.contains('dark'));
+    });
+  }
+
+  // Render star ratings
+  document.querySelectorAll('.rating').forEach(el => {
+    const value = parseFloat(el.dataset.rating);
+    const fullStars = Math.floor(value);
+    const half = value % 1 >= 0.5;
+    let stars = '★'.repeat(fullStars);
+    if (half) stars += '½';
+    el.textContent = stars;
+  });
+
+  // Summaries
+  if (topAuthorsEl || topGenresEl) {
+    const authorCount = {};
+    const genreCount = {};
+    posts.forEach(post => {
+      authorCount[post.dataset.author] = (authorCount[post.dataset.author] || 0) + 1;
+      genreCount[post.dataset.genre] = (genreCount[post.dataset.genre] || 0) + 1;
+    });
+    const topAuthors = Object.entries(authorCount).sort((a,b) => b[1]-a[1]).map(e => e[0]).slice(0,3).join(', ');
+    const topGenres = Object.entries(genreCount).sort((a,b) => b[1]-a[1]).map(e => e[0]).slice(0,3).join(', ');
+    if (topAuthorsEl) topAuthorsEl.textContent = topAuthors;
+    if (topGenresEl) topGenresEl.textContent = topGenres;
+  }
 
   function filterPosts() {
     const query = searchInput.value.toLowerCase();
     const authorVal = authorFilter.value;
     const tagVal = tagFilter.value;
+    const genreVal = genreFilter.value;
+    const ratingVal = parseFloat(ratingFilter.value || 0);
+    const yearVal = yearFilter.value;
 
     posts.forEach(post => {
       const text = post.dataset.excerpt.toLowerCase() + post.querySelector('h2').textContent.toLowerCase();
       const author = post.dataset.author;
       const tags = post.dataset.tags.split(',');
+      const genre = post.dataset.genre;
+      const rating = parseFloat(post.dataset.rating || 0);
+      const year = post.dataset.year;
       const matchesQuery = text.includes(query);
       const matchesAuthor = authorVal === '' || author === authorVal;
       const matchesTag = tagVal === '' || tags.includes(tagVal);
-      if (matchesQuery && matchesAuthor && matchesTag) {
+      const matchesGenre = genreVal === '' || genre === genreVal;
+      const matchesRating = ratingFilter.value === '' || rating >= ratingVal;
+      const matchesYear = yearVal === '' || year === yearVal;
+      if (matchesQuery && matchesAuthor && matchesTag && matchesGenre && matchesRating && matchesYear) {
         post.style.display = '';
       } else {
         post.style.display = 'none';
@@ -27,4 +84,7 @@ document.addEventListener('DOMContentLoaded', function () {
   searchInput.addEventListener('input', filterPosts);
   authorFilter.addEventListener('change', filterPosts);
   tagFilter.addEventListener('change', filterPosts);
+  genreFilter.addEventListener('change', filterPosts);
+  ratingFilter.addEventListener('change', filterPosts);
+  yearFilter.addEventListener('change', filterPosts);
 });

--- a/index.html
+++ b/index.html
@@ -4,6 +4,27 @@ title: Home
 ---
 <h1>Welcome to My Book Nook 🌟</h1>
 <p>A cosy little place where I share thoughts on books I love.</p>
+<blockquote id="quote-of-the-day"></blockquote>
+
+<div class="featured-carousel">
+  {% for post in site.posts %}
+    {% if post.featured %}
+    <div class="featured-item">
+      <a href="{{ site.baseurl }}{{ post.url }}">
+        {% if post.cover %}
+          <img src="{{ site.baseurl }}{{ post.cover }}" alt="{{ post.title }} cover" loading="lazy">
+        {% endif %}
+        <h3>{{ post.title }}</h3>
+      </a>
+    </div>
+    {% endif %}
+  {% endfor %}
+</div>
+
+<div class="summary">
+  <p><strong>Top Authors:</strong> <span id="top-authors"></span></p>
+  <p><strong>Popular Genres:</strong> <span id="top-genres"></span></p>
+</div>
 
 <div class="filters">
   <input type="text" id="search" placeholder="Search reviews...">
@@ -25,14 +46,37 @@ title: Home
       <option value="{{ tag }}">{{ tag }}</option>
     {% endfor %}
   </select>
+  <select id="genre-filter">
+    <option value="">All Genres</option>
+    {% assign genres = site.posts | map: "genre" | uniq | sort %}
+    {% for g in genres %}
+      <option value="{{ g }}">{{ g }}</option>
+    {% endfor %}
+  </select>
+  <select id="rating-filter">
+    <option value="">All Ratings</option>
+    {% for r in "0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5" | split: "," %}
+      <option value="{{ r }}">{{ r }}+</option>
+    {% endfor %}
+  </select>
+  <select id="year-filter">
+    <option value="">All Years</option>
+    {% assign years = site.posts | map: "publication_date" | map: "date" | map: "year" | uniq | sort %}
+    {% for y in years %}
+      <option value="{{ y }}">{{ y }}</option>
+    {% endfor %}
+  </select>
 </div>
 
 {% for post in site.posts %}
-<article class="review" data-author="{{ post.author }}" data-tags="{{ post.tags | join: ',' }}" data-date="{{ post.date | date_to_xmlschema }}" data-excerpt="{{ post.excerpt | strip_html | escape }}">
+<article class="review" data-author="{{ post.author }}" data-tags="{{ post.tags | join: ',' }}" data-date="{{ post.date | date_to_xmlschema }}" data-genre="{{ post.genre }}" data-rating="{{ post.rating }}" data-year="{{ post.publication_date | date: '%Y' }}" data-excerpt="{{ post.excerpt | strip_html | escape }}"> 
   <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
   <p class="meta">by {{ post.author }} — {{ post.date | date: '%B %d, %Y' }}</p>
   {% if post.cover %}
-    <img src="{{ site.baseurl }}{{ post.cover }}" alt="{{ post.title }} cover" class="cover">
+    <img src="{{ site.baseurl }}{{ post.cover }}" alt="{{ post.title }} cover" class="cover" loading="lazy">
+  {% endif %}
+  {% if post.rating %}
+    <p class="rating" data-rating="{{ post.rating }}"></p>
   {% endif %}
   <p class="tags">{{ post.tags | array_to_sentence_string }}</p>
   <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>


### PR DESCRIPTION
## Summary
- enrich post front matter with genre, publication date, rating and featured flag
- expand Netlify CMS fields to expose new metadata
- enable RSS and sitemap via Jekyll plugins
- show featured carousel, quote of the day and extended filters on homepage
- add dark mode toggle and ratings in layouts and styling
- provide JS logic for filtering, star ratings and summaries

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d9bea8980832f92337046c54fc67d